### PR TITLE
Dockerize gh-pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM coopermaa/alpine-nginx:1.6-onbuild

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Put these files on a host. Then, use any modern web browser to open them.
    $ python -m SimpleHTTPServer
    Serving HTTP on 0.0.0.0 port 8000 ...
    ```
+   Or just run this Docker image:
+   
+   ```
+   $ docker run -d williamyeh/docker-mini
+   ```
 
 2. Use any modern web browser to connect to the server's document root, e.g.,
 


### PR DESCRIPTION
Hi William, 

I'vd added a Dockerfile for gh-pages, FYI.

The Dockerfile of the base image `coopermaa/alpine-nginx` can be found here: https://github.com/coopermaa/my-docker-library/tree/master/alpine-nginx
